### PR TITLE
S3 Storage enforce_retention! corrections

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Sample config file**
+If possible, a sample config file that is able to reproduce the issue.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+Please complete the following information
+ - OS: [e.g. Debian 9]
+ - Ruby Version [e.g. `ruby --version`]
+ - RVM/rbenv Version [e.g. `rvm -v`]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+## Contributing
+
+First off, thank you for considering contributing to Martilla.
+
+This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+### Where do I go from here?
+
+If you've noticed a bug or have a question [search the issue tracker](https://github.com/fdoxyz/martilla/issues?q=) to see if someone else has already created a ticket. If not, go ahead and create a one[new issue](https://github.com/fdoxyz/martilla/issues/new/choose)!
+
+### Fork & create a branch
+
+If this is something you think you can fix, then [fork Martilla](https://help.github.com/articles/fork-a-repo) and create a branch with a descriptive name.
+
+A good branch name would be (where issue #325 is the ticket you're working on):
+
+```sh
+git checkout -b 325-add-japanese-translations
+```
+
+### Get the test suite running
+
+Make sure you're using a recent ruby and have the `bundler` gem installed, at least version `2.0.2`.
+
+Now install the development dependencies:
+
+```sh
+bundle install
+```
+
+Now you should be able to run the entire suite using:
+
+```sh
+bundle exec rspec
+```
+
+### Implement your fix or feature
+
+At this point, you're ready to make your changes! Feel free to ask for help; everyone is a beginner at first :)
+
+### Get the style right
+
+Your patch should follow the same conventions & pass the same code quality checks as the rest of the project. No linter is set in place at the moment but we're hoping to have one in place.
+
+### Make a Pull Request
+
+At this point, you should switch back to your master branch and make sure it's up to date with Martilla's master branch:
+
+```sh
+git remote add upstream git@github.com:fdoxyz/martilla.git
+git checkout master
+git pull upstream master
+```
+
+Then update your feature branch from your local copy of master, and push it!
+
+```sh
+git checkout 325-add-japanese-translations
+git rebase master
+git push --set-upstream origin 325-add-japanese-translations
+```
+
+Finally, go to GitHub and [make a Pull Request](https://help.github.com/articles/creating-a-pull-request) :D
+
+[Travis CI](https://travis-ci.org/) will run our test suite against all supported Ruby versions. We care about quality, so your PR won't be merged until all tests pass. It's unlikely, but it's possible that your changes pass tests in one Ruby version but fail in another.
+
+### Keeping your Pull Request updated
+
+If a maintainer asks you to "rebase" your PR, they're saying that a lot of code has changed, and that you need to update your branch so it's easier to merge.
+
+To learn more about rebasing in Git, there are a lot of good [git rebasing](http://git-scm.com/book/en/Git-Branching-Rebasing) & [interactive rebase](https://help.github.com/articles/interactive-rebase) resources but here's the suggested workflow:
+
+```sh
+git checkout 325-add-japanese-translations
+git pull --rebase upstream master
+git push --force-with-lease 325-add-japanese-translations
+```
+
+### Merging a PR (maintainers only)
+
+A PR can only be merged into master by a maintainer if:
+
+* It is passing CI.
+* It has no requested changes.
+* It is up to date with current master.
+
+Any maintainer is allowed to merge a PR if all of these conditions are met.
+
+### Shipping a release (maintainers only)
+
+Maintainers need to do the following to push out a release:
+
+* Make sure all pull requests are in and that [changelog](https://github.com/fdoxyz/martilla/blob/master/CHANGELOG.md) is current
+* Update `version.rb` file and changelog with new version number
+* If it's not a patch level release, create a stable branch for that release, otherwise switch to the stable branch corresponding to the patch release you want to ship:
+
+  ```sh
+  bundle install
+  git add .
+  git commit -m "v[X.Y.Z] release"
+  git push origin master
+  rake release
+  ```

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    martilla (0.3.1)
+    martilla (0.4.0.rc1)
       aws-sdk-s3 (~> 1.49)
       aws-sdk-ses (~> 1.26)
       memoist (~> 0.16.0)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The name Martilla comes from a local name for the [Kinkajou](https://en.wikipedi
    * [Notifiers](https://github.com/fdoxyz/martilla#notifiers)
    * [Perform a backup](https://github.com/fdoxyz/martilla#perform-a-backup)
 3. [Contributing](https://github.com/fdoxyz/martilla#contributing)
-4. [Development](https://github.com/fdoxyz/martilla#development)
 5. [License](https://github.com/fdoxyz/martilla#license)
 6. [Code of Conduct](https://github.com/fdoxyz/martilla#code-of-conduct)
 
@@ -170,14 +169,10 @@ As simple as running the `backup` command on the martilla CLI and passing as arg
 Help the help command help you
 
     $ martilla help
-    
+
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/fdoxyz/martilla. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Check out our [contributing guide](https://github.com/fdoxyz/martilla/blob/master/CONTRIBUTING.md)
 
 ## License
 

--- a/lib/martilla/storage.rb
+++ b/lib/martilla/storage.rb
@@ -26,8 +26,12 @@ module Martilla
       @options['suffix']
     end
 
+    def options_filename
+      @options['filename'] || 'backup.sql'
+    end
+
     def output_filename(gzip)
-      filename = @options['filename'] || 'backup.sql'
+      filename = options_filename
       filename = append_datetime_suffix(filename) if suffix?
       filename = "#{filename}.gz" if gzip
       filename

--- a/lib/martilla/storages/s3.rb
+++ b/lib/martilla/storages/s3.rb
@@ -4,9 +4,11 @@ module Martilla
   class S3 < Storage
     def persist(tmp_file:, gzip:)
       path = output_filename(gzip)
-      obj = s3_resource.bucket(bucket_name).object(path)
+      # Files in the root path of a bucket need to be stripped of './'
+      # See https://github.com/fdoxyz/martilla/issues/17
+      path.slice!(0, 2) if path[0...2] == './'
 
-      # Upload it
+      obj = s3_resource.bucket(bucket_name).object(path)
       return nil if obj.upload_file(tmp_file)
       raise Error.new('Error uploading backup to bucket')
     end
@@ -14,14 +16,43 @@ module Martilla
     def enfore_retention!(gzip:)
       return if retention_limit < 1
 
-      objs = s3_resource.bucket(bucket_name).objects.sort_by(&:last_modified)
+      objs = bucket_objs_for_retention(output_file: output_filename(gzip))
       while objs.count > retention_limit do
-        objs.first.delete
+        delete_params = { bucket: bucket_name, key: objs.first.key }
+        s3_resource.client.delete_object(delete_params)
         puts "Retention limit met. Removed the backup file: #{objs.shift.key}"
       end
     end
 
     private
+
+    # Returns array of objs in the bucket that match the backup output file
+    # format, ordered by `last_modified` where oldest is first and newest last
+    def bucket_objs_for_retention(output_file:)
+      res = s3_resource.client.list_objects({ bucket: bucket_name })
+      objs = res.contents.sort_by(&:last_modified)
+
+      # Path & File basename to check against to enforce retention restriction
+      path = File.dirname(output_file)
+      base_name = File.basename(output_file)
+
+      if suffix?
+        # When using a suffix make sure we replace the actual timestamp for a
+        # regexp, otherwise because of different timestamps they'll never match
+        index = base_name =~ timestamp_regex
+        base_name.slice!(timestamp_regex)
+        base_name.insert(index, "\\d{4}-\\d{2}-\\d{2}T\\d{6}")
+      end
+
+      # Rejects objects that don't match the directory location or if they don't
+      # match with the same file basename structure
+      objs.reject do |obj|
+        directory_mismatch = File.dirname(obj.key) != path
+        filename_mismatch = !(File.basename(obj.key) =~ /#{base_name}/)
+
+        directory_mismatch || filename_mismatch
+      end
+    end
 
     def s3_resource
       options = {}

--- a/lib/martilla/version.rb
+++ b/lib/martilla/version.rb
@@ -1,3 +1,3 @@
 module Martilla
-  VERSION = '0.3.1'
+  VERSION = '0.4.0.rc1'
 end

--- a/martilla.gemspec
+++ b/martilla.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |spec|
   spec.name          = 'martilla'
   spec.version       = Martilla::VERSION
   spec.authors       = ['Fernando Valverde']
-  spec.email         = ['fdov88@gmail.com']
+  spec.email         = ['fernando@visualcosita.com']
 
-  spec.summary       = 'Modern backup tool'
+  spec.summary       = 'Easy to configure backup tool for simple everyday use'
   spec.description   = ''
   spec.homepage      = 'https://github.com/fdoxyz/martilla'
   spec.license       = 'MIT'
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/fdoxyz/martilla'
-  spec.metadata['changelog_uri'] = 'https://github.com/fdoxyz/martilla/changelog'
+  spec.metadata['changelog_uri'] = 'https://github.com/fdoxyz/martilla/blob/master/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/databases/mysql_spec.rb
+++ b/spec/databases/mysql_spec.rb
@@ -45,5 +45,12 @@ RSpec.describe Martilla::Mysql do
       ENV['MYSQL_USER'] = nil
       ENV['MYSQL_PASSWORD'] = nil
     end
+
+    it 'using config paramters loaded from YAML file' do
+      config = YAML.load_file('spec/fixtures/mysql_special_characters.yml')
+      mysql = Martilla::Database.create(config['db'])
+      args = mysql.send(:connection_arguments)
+      expect(args).to eq('-u test --password=te&s%t_passw(^)rd --host=localhost -P 3306 --all-databases')
+    end
   end
 end

--- a/spec/databases/postgres_spec.rb
+++ b/spec/databases/postgres_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Martilla::Postgres do
     end
 
     it 'using config params' do
-      mysql = Martilla::Postgres.new(postgres_config)
-      args = mysql.send(:connection_string)
+      pg = Martilla::Postgres.new(postgres_config)
+      args = pg.send(:connection_string)
       expect(args).to eq('postgres://travis:pastrana@8.8.8.8:4444/test')
     end
 
@@ -32,8 +32,8 @@ RSpec.describe Martilla::Postgres do
       ENV['PG_PASSWORD'] = 'hawk'
       ENV['PG_DATABASE'] = 'sample'
 
-      mysql = Martilla::Postgres.new({})
-      args = mysql.send(:connection_string)
+      pg = Martilla::Postgres.new({})
+      args = pg.send(:connection_string)
       expect(args).to eq('postgres://tony:hawk@9.9.9.9:5555/sample')
     end
 
@@ -42,9 +42,16 @@ RSpec.describe Martilla::Postgres do
       ENV['PG_PASSWORD'] = 'hawk'
       ENV['PG_DATABASE'] = 'example'
 
-      mysql = Martilla::Postgres.new({})
-      args = mysql.send(:connection_string)
+      pg = Martilla::Postgres.new({})
+      args = pg.send(:connection_string)
       expect(args).to eq('postgres://tony:hawk@localhost:5432/example')
     end
   end
+
+  it 'using config paramters loaded from YAML file' do
+      config = YAML.load_file('spec/fixtures/postgres_special_characters.yml')
+      pg = Martilla::Database.create(config['db'])
+      args = pg.send(:connection_string)
+      expect(args).to eq('postgres://test:te&s%t_passw(^)rd@localhost:5432/sample-db')
+    end
 end

--- a/spec/fixtures/mysql_special_characters.yml
+++ b/spec/fixtures/mysql_special_characters.yml
@@ -1,0 +1,12 @@
+---
+db:
+  type: mysql
+  options:
+    user: test
+    password: te&s%t_passw(^)rd
+storage:
+  type: local
+  options:
+    filename: database-backup.sql
+notifiers:
+- type: none

--- a/spec/fixtures/postgres_special_characters.yml
+++ b/spec/fixtures/postgres_special_characters.yml
@@ -1,0 +1,13 @@
+---
+db:
+  type: postgres
+  options:
+    user: test
+    password: te&s%t_passw(^)rd
+    db: sample-db
+storage:
+  type: local
+  options:
+    filename: database-backup.sql
+notifiers:
+- type: none

--- a/spec/storages/s3_spec.rb
+++ b/spec/storages/s3_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe Martilla::S3 do
+  let(:output_file) { 'test/backup_2019-05-01T143129.sql.gz' }
+  let(:root_output_file) { 'backup_2019-05-01T143129.sql.gz' }
+
+  let(:subdirectory_s3_config) do
+    opts = Martilla::Backup.sample_config['storage']['options']
+    opts['filename'] = 'test/backup.sql'
+    opts['bucket'] = 'test'
+    opts['retention'] = 2
+    opts
+  end
+
+  let(:root_s3_config) do
+    opts = Martilla::Backup.sample_config['storage']['options']
+    opts['filename'] = 'backup.sql'
+    opts['bucket'] = 'test'
+    opts['retention'] = 2
+    opts
+  end
+
+  it 'enforces retention on valid files within a subdirectory in the bucket' do
+    # Override private `s3_resource` method to use custom Client with stubs
+    s3_storage = Martilla::S3.new(subdirectory_s3_config)
+    def s3_storage.s3_resource
+      s3_client = Aws::S3::Client.new(stub_responses: true)
+      s3_client.stub_responses(:list_objects, {
+        contents: [
+          { key: 'image.jpeg' },
+          { key: 'test/image.jpeg' },
+          { key: 'test/backup_2019-03-01T143129.sql.gz' },
+          { key: 'test/backup_2019-04-01T143129.sql.gz' },
+          { key: 'test/backup_2019-05-01T143129.sql.gz' },
+          { key: 'test/image2.jpeg' },
+          { key: 'backup_2019-06-01T143129.sql.gz' },
+          { key: 'backup_2019-07-01T143129.sql.gz' },
+          { key: 'backup_2019-08-01T143129.sql.gz' },
+          { key: 'backup_2019-09-01T143129.sql.gz' },
+          { key: 'backup_2019-10-01T143129.sql.gz' }
+        ]
+      })
+      Aws::S3::Resource.new({ client: s3_client })
+    end
+
+    objs = s3_storage.send(:bucket_objs_for_retention, output_file: output_file)
+    expect(objs.count).to eq(3)
+
+    result_keys = objs.map(&:key)
+    [
+      'test/backup_2019-03-01T143129.sql.gz',
+      'test/backup_2019-04-01T143129.sql.gz',
+      'test/backup_2019-05-01T143129.sql.gz'
+    ].each do |filename|
+      expect(result_keys).to include(filename)
+    end
+  end
+
+  it 'enforces retention on valid files in the bucket root directory' do
+    # Override private `s3_resource` method to use custom Client with stubs
+    root_s3_storage = Martilla::S3.new(root_s3_config)
+    def root_s3_storage.s3_resource
+      s3_client = Aws::S3::Client.new(stub_responses: true)
+      s3_client.stub_responses(:list_objects, {
+        contents: [
+          { key: 'image.jpeg' },
+          { key: 'test/image.jpeg' },
+          { key: 'test/backup_2019-03-01T143129.sql.gz' },
+          { key: 'test/backup_2019-04-01T143129.sql.gz' },
+          { key: 'test/backup_2019-05-01T143129.sql.gz' },
+          { key: 'test/image2.jpeg' },
+          { key: 'backup_2019-06-01T143129.sql.gz' },
+          { key: 'backup_2019-07-01T143129.sql.gz' },
+          { key: 'backup_2019-08-01T143129.sql.gz' },
+          { key: 'backup_2019-09-01T143129.sql.gz' },
+          { key: 'backup_2019-10-01T143129.sql.gz' }
+        ]
+      })
+      Aws::S3::Resource.new({ client: s3_client })
+    end
+
+    objs = root_s3_storage.send(:bucket_objs_for_retention, output_file: root_output_file)
+    expect(objs.count).to eq(5)
+
+    result_keys = objs.map(&:key)
+    [
+      'backup_2019-06-01T143129.sql.gz',
+      'backup_2019-07-01T143129.sql.gz',
+      'backup_2019-08-01T143129.sql.gz',
+      'backup_2019-09-01T143129.sql.gz',
+      'backup_2019-10-01T143129.sql.gz'
+    ].each do |filename|
+      expect(result_keys).to include(filename)
+    end
+  end
+end

--- a/spec/storages/s3_spec.rb
+++ b/spec/storages/s3_spec.rb
@@ -18,77 +18,89 @@ RSpec.describe Martilla::S3 do
     opts
   end
 
-  it 'enforces retention on valid files within a subdirectory in the bucket' do
-    # Override private `s3_resource` method to use custom Client with stubs
-    s3_storage = Martilla::S3.new(subdirectory_s3_config)
-    def s3_storage.s3_resource
-      s3_client = Aws::S3::Client.new(stub_responses: true)
-      s3_client.stub_responses(:list_objects, {
-        contents: [
-          { key: 'image.jpeg' },
-          { key: 'test/image.jpeg' },
-          { key: 'test/backup_2019-03-01T143129.sql.gz' },
-          { key: 'test/backup_2019-04-01T143129.sql.gz' },
-          { key: 'test/backup_2019-05-01T143129.sql.gz' },
-          { key: 'test/image2.jpeg' },
-          { key: 'backup_2019-06-01T143129.sql.gz' },
-          { key: 'backup_2019-07-01T143129.sql.gz' },
-          { key: 'backup_2019-08-01T143129.sql.gz' },
-          { key: 'backup_2019-09-01T143129.sql.gz' },
-          { key: 'backup_2019-10-01T143129.sql.gz' }
-        ]
-      })
-      Aws::S3::Resource.new({ client: s3_client })
+  describe 'retention enforcement' do
+    it 'on valid files within a subdirectory in the bucket' do
+      # Override private `s3_resource` method to use custom Client with stubs
+      s3_storage = Martilla::S3.new(subdirectory_s3_config)
+      def s3_storage.s3_resource
+        s3_client = Aws::S3::Client.new(stub_responses: true)
+        s3_client.stub_responses(:list_objects, {
+          contents: [
+            { key: 'image.jpeg' },
+            { key: 'test/image.jpeg' },
+            { key: 'test/backup_2019-03-01T143129.sql.gz' },
+            { key: 'test/backup_2019-04-01T143129.sql.gz' },
+            { key: 'test/backup_2019-05-01T143129.sql.gz' },
+            { key: 'test/image2.jpeg' },
+            { key: 'backup_2019-06-01T143129.sql.gz' },
+            { key: 'backup_2019-07-01T143129.sql.gz' },
+            { key: 'backup_2019-08-01T143129.sql.gz' },
+            { key: 'backup_2019-09-01T143129.sql.gz' },
+            { key: 'backup_2019-10-01T143129.sql.gz' }
+          ]
+        })
+        Aws::S3::Resource.new({ client: s3_client })
+      end
+
+      objs = s3_storage.send(:bucket_objs_for_retention, output_file: output_file)
+      expect(objs.count).to eq(3)
+
+      result_keys = objs.map(&:key)
+      [
+        'test/backup_2019-03-01T143129.sql.gz',
+        'test/backup_2019-04-01T143129.sql.gz',
+        'test/backup_2019-05-01T143129.sql.gz'
+      ].each do |filename|
+        expect(result_keys).to include(filename)
+      end
     end
 
-    objs = s3_storage.send(:bucket_objs_for_retention, output_file: output_file)
-    expect(objs.count).to eq(3)
+    it 'on valid files in the bucket root directory' do
+      # Override private `s3_resource` method to use custom Client with stubs
+      root_s3_storage = Martilla::S3.new(root_s3_config)
+      def root_s3_storage.s3_resource
+        s3_client = Aws::S3::Client.new(stub_responses: true)
+        s3_client.stub_responses(:list_objects, {
+          contents: [
+            { key: 'image.jpeg' },
+            { key: 'test/image.jpeg' },
+            { key: 'test/backup_2019-03-01T143129.sql.gz' },
+            { key: 'test/backup_2019-04-01T143129.sql.gz' },
+            { key: 'test/backup_2019-05-01T143129.sql.gz' },
+            { key: 'test/image2.jpeg' },
+            { key: 'backup_2019-06-01T143129.sql.gz' },
+            { key: 'backup_2019-07-01T143129.sql.gz' },
+            { key: 'backup_2019-08-01T143129.sql.gz' },
+            { key: 'backup_2019-09-01T143129.sql.gz' },
+            { key: 'backup_2019-10-01T143129.sql.gz' }
+          ]
+        })
+        Aws::S3::Resource.new({ client: s3_client })
+      end
 
-    result_keys = objs.map(&:key)
-    [
-      'test/backup_2019-03-01T143129.sql.gz',
-      'test/backup_2019-04-01T143129.sql.gz',
-      'test/backup_2019-05-01T143129.sql.gz'
-    ].each do |filename|
-      expect(result_keys).to include(filename)
+      objs = root_s3_storage.send(:bucket_objs_for_retention, output_file: root_output_file)
+      expect(objs.count).to eq(5)
+
+      result_keys = objs.map(&:key)
+      [
+        'backup_2019-06-01T143129.sql.gz',
+        'backup_2019-07-01T143129.sql.gz',
+        'backup_2019-08-01T143129.sql.gz',
+        'backup_2019-09-01T143129.sql.gz',
+        'backup_2019-10-01T143129.sql.gz'
+      ].each do |filename|
+        expect(result_keys).to include(filename)
+      end
     end
   end
 
-  it 'enforces retention on valid files in the bucket root directory' do
-    # Override private `s3_resource` method to use custom Client with stubs
-    root_s3_storage = Martilla::S3.new(root_s3_config)
-    def root_s3_storage.s3_resource
-      s3_client = Aws::S3::Client.new(stub_responses: true)
-      s3_client.stub_responses(:list_objects, {
-        contents: [
-          { key: 'image.jpeg' },
-          { key: 'test/image.jpeg' },
-          { key: 'test/backup_2019-03-01T143129.sql.gz' },
-          { key: 'test/backup_2019-04-01T143129.sql.gz' },
-          { key: 'test/backup_2019-05-01T143129.sql.gz' },
-          { key: 'test/image2.jpeg' },
-          { key: 'backup_2019-06-01T143129.sql.gz' },
-          { key: 'backup_2019-07-01T143129.sql.gz' },
-          { key: 'backup_2019-08-01T143129.sql.gz' },
-          { key: 'backup_2019-09-01T143129.sql.gz' },
-          { key: 'backup_2019-10-01T143129.sql.gz' }
-        ]
-      })
-      Aws::S3::Resource.new({ client: s3_client })
-    end
-
-    objs = root_s3_storage.send(:bucket_objs_for_retention, output_file: root_output_file)
-    expect(objs.count).to eq(5)
-
-    result_keys = objs.map(&:key)
-    [
-      'backup_2019-06-01T143129.sql.gz',
-      'backup_2019-07-01T143129.sql.gz',
-      'backup_2019-08-01T143129.sql.gz',
-      'backup_2019-09-01T143129.sql.gz',
-      'backup_2019-10-01T143129.sql.gz'
-    ].each do |filename|
-      expect(result_keys).to include(filename)
-    end
+  it 'creates an Aws::S3::Resource using config paramters' do |variable|
+    db_config = {
+      'region' => 'us-east-1',
+      'access_key_id' => 'DUMMY_ACCESS_KEY_ID',
+      'secret_access_key' => 'DUMMY_SECRET_ACCESS_KEY',
+    }
+    s3_storage = Martilla::S3.new(db_config)
+    expect(s3_storage.send(:s3_resource)).to be_instance_of(Aws::S3::Resource)
   end
 end


### PR DESCRIPTION
This PR is intended to fix #18 

`enforce_retention!` for the S3 Storage component will now filter objects from the bucket returned by the AWS S3 request to match only the backup files generated by Martilla. All other objects from the S3 bucket should be safe from retention enforcement (unless they're named similarly and located next to other backups).

Changes were also introduced in order to fix #17 too. The root folder should work as a valid location to store backups.

Valid **storage** options are the following:
 - `filename: 'path/to/backups/database-backup.sql'`
   - Using subdirectory for storing backups
 - `filename: 'database-backup.sql'`
   - Using root directory for storing backups